### PR TITLE
Allow constraint-based resizing for journey stop view

### DIFF
--- a/ICE Buddy/JourneyStopCustomViewController.xib
+++ b/ICE Buddy/JourneyStopCustomViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22155" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22155"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -21,9 +21,8 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView misplaced="YES" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="333" height="33"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
+            <rect key="frame" x="0.0" y="0.0" width="333" height="32"/>
             <subviews>
                 <imageView horizontalHuggingPriority="246" verticalHuggingPriority="246" horizontalCompressionResistancePriority="744" verticalCompressionResistancePriority="742" translatesAutoresizingMaskIntoConstraints="NO" id="oUO-NY-mPM">
                     <rect key="frame" x="12" y="10" width="12" height="12"/>
@@ -33,7 +32,7 @@
                     </constraints>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="stop_icon" id="NHg-3Q-lWx"/>
                 </imageView>
-                <textField horizontalHuggingPriority="246" verticalHuggingPriority="750" horizontalCompressionResistancePriority="748" translatesAutoresizingMaskIntoConstraints="NO" id="MUz-Zg-syW">
+                <textField focusRingType="none" horizontalHuggingPriority="246" verticalHuggingPriority="750" horizontalCompressionResistancePriority="748" translatesAutoresizingMaskIntoConstraints="NO" id="MUz-Zg-syW">
                     <rect key="frame" x="32" y="8" width="96" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="200" id="Dee-q5-lHR"/>
@@ -55,7 +54,7 @@
                 <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EeZ-0x-y4a">
                     <rect key="frame" x="184" y="8" width="129" height="16"/>
                     <subviews>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ARd-fJ-jiR">
+                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ARd-fJ-jiR">
                             <rect key="frame" x="-2" y="0.0" width="39" height="16"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" title="18:59" id="tXd-sO-ohi">
                                 <font key="font" metaFont="system"/>
@@ -63,7 +62,7 @@
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7VP-jg-Pym">
+                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7VP-jg-Pym">
                             <rect key="frame" x="41" y="0.0" width="27" height="16"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" title="+15" id="MRj-Tv-jfj">
                                 <font key="font" metaFont="system"/>
@@ -71,7 +70,7 @@
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mfo-hb-yTJ">
+                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mfo-hb-yTJ">
                             <rect key="frame" x="72" y="0.0" width="59" height="16"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="55" id="efD-M9-fBU"/>

--- a/ICE Buddy/JourneyStopCustomViewController.xib
+++ b/ICE Buddy/JourneyStopCustomViewController.xib
@@ -32,11 +32,8 @@
                     </constraints>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="stop_icon" id="NHg-3Q-lWx"/>
                 </imageView>
-                <textField focusRingType="none" horizontalHuggingPriority="246" verticalHuggingPriority="750" horizontalCompressionResistancePriority="748" translatesAutoresizingMaskIntoConstraints="NO" id="MUz-Zg-syW">
+                <textField focusRingType="none" horizontalHuggingPriority="246" verticalHuggingPriority="750" horizontalCompressionResistancePriority="748" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="MUz-Zg-syW">
                     <rect key="frame" x="32" y="8" width="96" height="16"/>
-                    <constraints>
-                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="200" id="Dee-q5-lHR"/>
-                    </constraints>
                     <textFieldCell key="cell" title="Berlin Spandau" id="HXv-bf-4as">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -101,6 +98,7 @@
             <constraints>
                 <constraint firstItem="T42-m2-47b" firstAttribute="leading" secondItem="oUO-NY-mPM" secondAttribute="leading" id="0V7-Ts-ibu"/>
                 <constraint firstItem="T42-m2-47b" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="3Cn-Ee-55B"/>
+                <constraint firstAttribute="width" constant="333" id="5CN-VE-Uih"/>
                 <constraint firstItem="T42-m2-47b" firstAttribute="trailing" secondItem="oUO-NY-mPM" secondAttribute="trailing" id="BBV-wB-UJo"/>
                 <constraint firstItem="Fm7-Tu-dXK" firstAttribute="leading" secondItem="MUz-Zg-syW" secondAttribute="trailing" constant="8" symbolic="YES" id="F01-kr-331"/>
                 <constraint firstItem="ARd-fJ-jiR" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Fm7-Tu-dXK" secondAttribute="trailing" constant="10" id="Koz-tC-pFg"/>

--- a/ICE Buddy/JourneyStopCustomViewController.xib
+++ b/ICE Buddy/JourneyStopCustomViewController.xib
@@ -103,6 +103,7 @@
                 <constraint firstItem="T42-m2-47b" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="3Cn-Ee-55B"/>
                 <constraint firstItem="T42-m2-47b" firstAttribute="trailing" secondItem="oUO-NY-mPM" secondAttribute="trailing" id="BBV-wB-UJo"/>
                 <constraint firstItem="Fm7-Tu-dXK" firstAttribute="leading" secondItem="MUz-Zg-syW" secondAttribute="trailing" constant="8" symbolic="YES" id="F01-kr-331"/>
+                <constraint firstItem="ARd-fJ-jiR" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Fm7-Tu-dXK" secondAttribute="trailing" constant="10" id="Koz-tC-pFg"/>
                 <constraint firstItem="oUO-NY-mPM" firstAttribute="centerY" secondItem="MUz-Zg-syW" secondAttribute="centerY" id="QJd-Q9-Vw4"/>
                 <constraint firstItem="MUz-Zg-syW" firstAttribute="leading" secondItem="oUO-NY-mPM" secondAttribute="trailing" constant="10" id="SO1-Lt-vVs"/>
                 <constraint firstItem="oUO-NY-mPM" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="12" id="brn-Lk-CId"/>
@@ -118,7 +119,7 @@
                 <constraint firstItem="MUz-Zg-syW" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="8" id="wuo-A1-mVc"/>
                 <constraint firstAttribute="trailing" secondItem="EeZ-0x-y4a" secondAttribute="trailing" constant="20" symbolic="YES" id="yJO-HY-Vgo"/>
             </constraints>
-            <point key="canvasLocation" x="-127.5" y="69.5"/>
+            <point key="canvasLocation" x="-127.5" y="69"/>
         </customView>
     </objects>
     <resources>

--- a/ICE Buddy/JourneyStopCustomViewController.xib
+++ b/ICE Buddy/JourneyStopCustomViewController.xib
@@ -72,7 +72,7 @@
                             <constraints>
                                 <constraint firstAttribute="width" constant="55" id="efD-M9-fBU"/>
                             </constraints>
-                            <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Gleis 222" id="Zxn-3H-cny">
+                            <textFieldCell key="cell" alignment="right" title="Gleis 22" id="Zxn-3H-cny">
                                 <font key="font" metaFont="system"/>
                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
This fixes truncation of longer journey stops, such as "Frankfurt(M) Flughafen Fernbf".

While the fix in #3 truncates the label, this version allows resizing the menu entry to multiple lines (which I believe was the originally intended design).